### PR TITLE
extend bundle version parsing to allow semver

### DIFF
--- a/pkg/util/bundle/bundle.go
+++ b/pkg/util/bundle/bundle.go
@@ -2,7 +2,10 @@ package bundle
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -20,32 +23,77 @@ var (
 	AMD64 BundleArch = "amd64"
 )
 
-var (
-	bundleVersionRegex = "\\d.\\d+.\\d+"
-)
+type FilenameInfo struct {
+	Preset             string
+	Driver             string
+	Version            string
+	Arch               string
+	CustomBundleSuffix string
+}
 
 // Bundle name format contains the version number we are managing
 // this function will return a description having that versioning info in it
 // if bundle name does not mach the default format version will be reported as unknown
 func GetDescription(bundleURL string, bundleArch *BundleArch) (*string, error) {
-	var bundleVersion string
-	bundleNameRegex := fmt.Sprintf("crc_libvirt_%s_%s.crcbundle", bundleVersionRegex, *bundleArch)
-	rn, err := regexp.Compile(bundleNameRegex)
+	bundleName, err := GetBundleNameFromURI(bundleURL)
 	if err != nil {
 		return nil, err
 	}
-	bundleName := rn.FindString(bundleURL)
-	if len(bundleName) > 0 {
-		rv, err := regexp.Compile(bundleVersionRegex)
-		if err != nil {
-			return nil, err
-		}
-		bundleVersion = rv.FindString(bundleName)
-		if len(bundleVersion) == 0 {
-			bundleVersion = bundleVersionUnknown
-		}
+	bundleInfo, err := GetBundleInfoFromName(bundleName)
+	if err != nil {
+		return nil, err
 	}
 	description :=
-		fmt.Sprintf("%s-%s", bundleDescription, bundleVersion)
+		fmt.Sprintf("%s-%s", bundleDescription, bundleInfo.Version)
 	return &description, nil
+}
+
+// https://github.com/crc-org/crc/blob/main/pkg/crc/machine/bundle/metadata.go#L263
+// GetBundleInfoFromName Parses the bundle filename and returns a FilenameInfo struct
+func GetBundleInfoFromName(bundleName string) (*FilenameInfo, error) {
+	var filenameInfo FilenameInfo
+
+	/*
+		crc_preset_driver_version_arch_customSuffix.crcbundle
+
+		crc                                : Matches the fixed crc part
+		(?:(?:_)([[:alpha:]]+))?           : Matches the preset part (optional)
+		([[:alpha:]]+)                     : Matches the next mandatory alphabetic part (e.g., libvirt)
+		(%s = semverRegex)                 : Matches the version in SemVer format (e.g., 4.16.7 or 4.16.7-ec.2)
+		([[:alnum:]]+)                     : Matches the architecture or platform part (e.g. amd64)
+		(?:_([0-9]+)(?:_([0-9]+))?)?       : Matches an optional underscore + number (_1234), followed optionally by another underscore + number (_5678)
+		\.crcbundle                        : Matches the file extension .crcbundle
+	*/
+	semverRegex := "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-(?:(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?:[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+	bundleRegex := `crc(?:(?:_)([[:alpha:]]+))?_([[:alpha:]]+)_(%s)_([[:alnum:]]+)(?:_([0-9]+)(?:_([0-9]+))?)?\.crcbundle`
+	compiledRegex := regexp.MustCompile(fmt.Sprintf(bundleRegex, semverRegex))
+	filenameParts := compiledRegex.FindStringSubmatch(bundleName)
+
+	if filenameParts == nil {
+		return &filenameInfo, fmt.Errorf("bundle filename is in unrecognized format")
+	}
+
+	if filenameParts[1] == "" {
+		filenameInfo.Preset = "openshift"
+	} else {
+		filenameInfo.Preset = "microshift"
+	}
+	filenameInfo.Driver = filenameParts[2]
+	filenameInfo.Version = filenameParts[3]
+	filenameInfo.Arch = filenameParts[4]
+	filenameInfo.CustomBundleSuffix = filenameParts[5]
+
+	return &filenameInfo, nil
+}
+
+func GetBundleNameFromURI(bundleURI string) (string, error) {
+	switch {
+	case strings.HasPrefix(bundleURI, "http://"), strings.HasPrefix(bundleURI, "https://"):
+		return path.Base(bundleURI), nil
+	case strings.HasPrefix(bundleURI, "file://"):
+		return path.Base(bundleURI), nil
+	default:
+		// local path
+		return filepath.Base(bundleURI), nil
+	}
 }


### PR DESCRIPTION
this uses the bundle version parsing code from crc and allows cloud-importer to use bundles with versions like: 4.19.0-ec.4