### PR TITLE
chore: added hack script to get info about the AMIs for rhel-ai

### DIFF
--- a/hacks/describe-amis.sh
+++ b/hacks/describe-amis.sh
@@ -1,0 +1,13 @@
+export AWS_PAGER=""
+for region in $(aws ec2 describe-regions --output text --query 'Regions[].RegionName'); do
+results=$(aws ec2 describe-images --region "$region" --owners self amazon --filters "Name=name,Values=rhel-ai*" --output text --query "Images[].[ImageId,Name]")
+if [ ! -z "$results" ]; then
+    echo "$results" | while IFS=$'\t' read -r ami_id name; do
+    echo "ResourceType: AMI"
+    echo "ResourceID: $ami_id"
+    echo "ResourceName: $name"
+    echo "Region: $region"
+    echo ""
+    done
+fi
+done


### PR DESCRIPTION
This PR adds a helper script to get info about AMIS, ATM it is fixed for a regex to rhel-ai but it should be easily customizable for other names...

This is mainly b/c to avoid prube some resources we need to identify them with this specific format: 

https://devservices.dpp.openshift.com/support/aws_preserve_resource_request/ 