### PR TITLE
fix(aws): fix duplicate Pulumi URN crash when sharing AMI with multiple accounts

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -47,6 +47,9 @@ func RHELAI(ctx *context.ContextArgs,
 	if err != nil {
 		return err
 	}
+	if err := p.ValidateShareTargets(args.ImageControl.ShareOrgIds); err != nil {
+		return err
+	}
 	ephemeralStack := providerAPI.Stack{
 		ProjectName: context.ProjectName(),
 		StackName:   stackRHELAIEphemeral,
@@ -88,6 +91,9 @@ func SNC(ctx *context.ContextArgs, args *SNCArgs, provider Provider) error {
 	}
 	p, err := getProvider(provider)
 	if err != nil {
+		return err
+	}
+	if err := p.ValidateShareTargets(args.ImageControl.ShareOrgIds); err != nil {
 		return err
 	}
 	ephemeralStack := providerAPI.Stack{

--- a/pkg/manager/provider/api/api.go
+++ b/pkg/manager/provider/api/api.go
@@ -19,6 +19,9 @@ type Provider interface {
 	RHELAIEphemeral(imageFilePath, imageName string) pulumi.RunFunc
 	// Manage ephemeral assets
 	SNCEphemeral(bundleURI, shasumURI, arch string) pulumi.RunFunc
+	// ValidateShareTargets checks share target identifiers for errors (e.g. duplicates)
+	// before any upload or resource creation begins. Returns an error if the targets are invalid.
+	ValidateShareTargets(shareOrgIds []string) error
 	// Register AMI and keep state
 	ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error)
 	// Manage Provider Credentials

--- a/pkg/provider/aws/ami.go
+++ b/pkg/provider/aws/ami.go
@@ -130,13 +130,11 @@ func (r *registerRequest) newAMI(ctx *pulumi.Context) (*ec2.Ami, error) {
 		return nil, err
 	}
 	for _, orgArn := range r.shareorgARNs {
+		lArgs := launchPermArgs(ami.ID(), orgArn)
 		_, err = ec2.NewAmiLaunchPermission(
 			ctx,
 			fmt.Sprintf("%s-%s", r.name, orgId(&orgArn)),
-			&ec2.AmiLaunchPermissionArgs{
-				ImageId:         ami.ID(),
-				OrganizationArn: pulumi.String(orgArn),
-			})
+			lArgs)
 		if err != nil {
 			return nil, err
 		}
@@ -173,14 +171,12 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 	}
 	var amiPermissions *ec2.AmiLaunchPermission
 	for _, orgArn := range args.shareOrgARNs {
+		lArgs := launchPermArgs(ami.ID(), orgArn)
+		lArgs.Region = pulumi.String(targetRegion)
 		amiPermissions, err = ec2.NewAmiLaunchPermission(
 			args.ctx,
 			fmt.Sprintf("%s-%s-%s", *args.name, targetRegion, orgId(&orgArn)),
-			&ec2.AmiLaunchPermissionArgs{
-				ImageId:         ami.ID(),
-				OrganizationArn: pulumi.String(orgArn),
-				Region:          pulumi.String(targetRegion),
-			})
+			lArgs)
 		if err != nil {
 			hostingPlaces.SendAsyncErr(c, err)
 			return
@@ -195,10 +191,36 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 		Err: nil}
 }
 
+// orgId returns a string suitable for use as a unique Pulumi resource name suffix.
+// Accepts either a plain AWS account ID ("851725220677") or an organizations ARN.
 func orgId(orgARN *string) string {
+	if !strings.HasPrefix(*orgARN, "arn:") {
+		return *orgARN
+	}
 	r := strings.Split(*orgARN, ":")[5]
 	parts := strings.Split(r, "/")
 	return strings.Join(parts[1:], "-")
+}
+
+// launchPermArgs builds AmiLaunchPermissionArgs routing to the correct field.
+// Accepts a plain 12-digit account ID or an organizations ARN
+// (organization→OrganizationArn, ou→OrganizationalUnitArn, account→AccountId).
+func launchPermArgs(imageId pulumi.StringInput, arn string) *ec2.AmiLaunchPermissionArgs {
+	args := &ec2.AmiLaunchPermissionArgs{ImageId: imageId}
+	if !strings.HasPrefix(arn, "arn:") {
+		args.AccountId = pulumi.String(arn)
+		return args
+	}
+	parts := strings.Split(strings.Split(arn, ":")[5], "/")
+	switch parts[0] {
+	case "account":
+		args.AccountId = pulumi.String(parts[len(parts)-1])
+	case "ou":
+		args.OrganizationalUnitArn = pulumi.String(arn)
+	default: // "organization"
+		args.OrganizationArn = pulumi.String(arn)
+	}
+	return args
 }
 
 // mergeTags combines context tags with resource-specific tags.

--- a/pkg/provider/aws/ami.go
+++ b/pkg/provider/aws/ami.go
@@ -20,6 +20,10 @@ var (
 	outBucketName = "rolename"
 )
 
+func (a *aws) ValidateShareTargets(shareOrgIds []string) error {
+	return validateShareOrgIds(shareOrgIds)
+}
+
 func (a *aws) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error) {
 	if err := validateShareOrgIds(shareOrgIds); err != nil {
 		return nil, err
@@ -136,7 +140,7 @@ func (r *registerRequest) newAMI(ctx *pulumi.Context) (*ec2.Ami, error) {
 		lArgs := launchPermArgs(ami.ID(), orgArn)
 		_, err = ec2.NewAmiLaunchPermission(
 			ctx,
-			fmt.Sprintf("%s-%s", r.name, orgId(&orgArn)),
+			fmt.Sprintf("%s-%s", r.name, pulumiResourceId(orgArn)),
 			lArgs)
 		if err != nil {
 			return nil, err
@@ -178,7 +182,7 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 		lArgs.Region = pulumi.String(targetRegion)
 		amiPermissions, err = ec2.NewAmiLaunchPermission(
 			args.ctx,
-			fmt.Sprintf("%s-%s-%s", *args.name, targetRegion, orgId(&orgArn)),
+			fmt.Sprintf("%s-%s-%s", *args.name, targetRegion, pulumiResourceId(orgArn)),
 			lArgs)
 		if err != nil {
 			hostingPlaces.SendAsyncErr(c, err)
@@ -203,7 +207,7 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 func validateShareOrgIds(ids []string) error {
 	seen := make(map[string]string, len(ids))
 	for _, id := range ids {
-		key := orgId(&id)
+		key := pulumiResourceId(id)
 		if prev, exists := seen[key]; exists {
 			return fmt.Errorf(
 				"duplicate share target: %q and %q resolve to the same identifier %q — "+
@@ -215,14 +219,41 @@ func validateShareOrgIds(ids []string) error {
 	return nil
 }
 
-// orgId returns a string suitable for use as a unique Pulumi resource name suffix.
-// Accepts either a plain AWS account ID ("851725220677") or an organizations ARN.
-func orgId(orgARN *string) string {
-	if !strings.HasPrefix(*orgARN, "arn:") {
-		return *orgARN
+// pulumiResourceId returns a string used only as a Pulumi resource name suffix —
+// it is never sent to AWS. The full original ARN is passed to AWS unchanged via
+// launchPermArgs.
+//
+// The suffix is derived from the ARN's resource path segments, intentionally
+// excluding the management account ID (MGMT). MGMT is excluded because it does
+// not change the AWS share target: an organization has exactly one management
+// account, so two org ARNs with the same org ID but different MGMT values
+// represent the same AWS target (one MGMT value must be wrong). Excluding MGMT
+// means validateShareOrgIds correctly identifies such pairs as duplicates and
+// returns a clear error rather than silently creating two Pulumi resources and
+// letting AWS reject the one with the bad MGMT.
+//
+// Accepted input forms and their output:
+//
+//	Plain account ID   "851725220677"                                        → "851725220677"
+//	Org-level ARN      "arn:aws:organizations::MGMT:organization/o-xxx"      → "o-xxx"
+//	Account-level ARN  "arn:aws:organizations::MGMT:account/o-xxx/ACCT_ID"  → "o-xxx-ACCT_ID"
+//	OU-level ARN       "arn:aws:organizations::MGMT:ou/o-xxx/ou-yyy-zzz"    → "o-xxx-ou-yyy-zzz"
+//
+// Malformed ARNs (starting with "arn:" but with too few colon-separated segments
+// or no "/" in the resource part) are returned as-is to avoid a panic; they will
+// surface an error at the Pulumi or AWS layer.
+func pulumiResourceId(arn string) string {
+	if !strings.HasPrefix(arn, "arn:") {
+		return arn
 	}
-	r := strings.Split(*orgARN, ":")[5]
-	parts := strings.Split(r, "/")
+	segments := strings.Split(arn, ":")
+	if len(segments) < 6 {
+		return arn
+	}
+	parts := strings.Split(segments[5], "/")
+	if len(parts) < 2 {
+		return arn
+	}
 	return strings.Join(parts[1:], "-")
 }
 

--- a/pkg/provider/aws/ami.go
+++ b/pkg/provider/aws/ami.go
@@ -21,6 +21,9 @@ var (
 )
 
 func (a *aws) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error) {
+	if err := validateShareOrgIds(shareOrgIds); err != nil {
+		return nil, err
+	}
 	amiNameOutput, ok := ephemeralResults.Outputs[outAMIName]
 	if !ok {
 		return nil, fmt.Errorf("output not found: %s", outAMIName)
@@ -189,6 +192,27 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 			amiPermissions: amiPermissions,
 		},
 		Err: nil}
+}
+
+// validateShareOrgIds returns an error if any two entries in ids resolve to the
+// same orgId key, which would cause a duplicate Pulumi URN at resource creation
+// time. Note: a plain account ID (e.g. "851725220677") and a full account-level
+// ARN for the same account produce different keys and are not detected as
+// duplicates here; normalising across those formats would require an
+// organisations:DescribeAccount lookup that may not be available to the caller.
+func validateShareOrgIds(ids []string) error {
+	seen := make(map[string]string, len(ids))
+	for _, id := range ids {
+		key := orgId(&id)
+		if prev, exists := seen[key]; exists {
+			return fmt.Errorf(
+				"duplicate share target: %q and %q resolve to the same identifier %q — "+
+					"check for duplicate entries or conflicting management account IDs in org ARNs",
+				prev, id, key)
+		}
+		seen[key] = id
+	}
+	return nil
 }
 
 // orgId returns a string suitable for use as a unique Pulumi resource name suffix.

--- a/pkg/provider/aws/ami.go
+++ b/pkg/provider/aws/ami.go
@@ -197,7 +197,8 @@ func replicaAsync(targetRegion string, args replicateArgs, c chan hostingPlaces.
 
 func orgId(orgARN *string) string {
 	r := strings.Split(*orgARN, ":")[5]
-	return strings.Split(r, "/")[1]
+	parts := strings.Split(r, "/")
+	return strings.Join(parts[1:], "-")
 }
 
 // mergeTags combines context tags with resource-specific tags.

--- a/pkg/provider/aws/ami_test.go
+++ b/pkg/provider/aws/ami_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestOrgId(t *testing.T) {
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "org-level ARN returns org ID",
+			arn:      "arn:aws:organizations::329260820478:organization/o-melcpnc7lj",
+			expected: "o-melcpnc7lj",
+		},
+		{
+			name:     "account-level ARN returns org-account compound ID",
+			arn:      "arn:aws:organizations::329260820478:account/o-melcpnc7lj/851725220677",
+			expected: "o-melcpnc7lj-851725220677",
+		},
+		{
+			name:     "second account-level ARN from same org returns different ID",
+			arn:      "arn:aws:organizations::329260820478:account/o-melcpnc7lj/585132637328",
+			expected: "o-melcpnc7lj-585132637328",
+		},
+		{
+			name:     "OU-level ARN returns ou compound ID",
+			arn:      "arn:aws:organizations::329260820478:ou/o-melcpnc7lj/ou-xxxx-yyyyyyyy",
+			expected: "o-melcpnc7lj-ou-xxxx-yyyyyyyy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orgId(&tt.arn)
+			if got != tt.expected {
+				t.Errorf("orgId(%q) = %q, want %q", tt.arn, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestOrgIdUniqueness verifies that two account ARNs from the same org produce
+// distinct resource name suffixes (the root cause of issue #82).
+func TestOrgIdUniqueness(t *testing.T) {
+	arn1 := "arn:aws:organizations::329260820478:account/o-melcpnc7lj/851725220677"
+	arn2 := "arn:aws:organizations::329260820478:account/o-melcpnc7lj/585132637328"
+
+	id1 := orgId(&arn1)
+	id2 := orgId(&arn2)
+
+	if id1 == id2 {
+		t.Errorf("two account ARNs from the same org produced the same ID %q — would cause duplicate Pulumi URN", id1)
+	}
+}

--- a/pkg/provider/aws/ami_test.go
+++ b/pkg/provider/aws/ami_test.go
@@ -110,3 +110,107 @@ func TestLaunchPermArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestOrgIdOrgLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "org ARN with one management account",
+			arn:      "arn:aws:organizations::329260820478:organization/o-meltunc7lj",
+			expected: "o-meltunc7lj",
+		},
+		{
+			name:     "org ARN with different management account, same org ID",
+			arn:      "arn:aws:organizations::329260824578:organization/o-meltunc7lj",
+			expected: "o-meltunc7lj",
+		},
+		{
+			name:     "org ARN with different org ID",
+			arn:      "arn:aws:organizations::329260820478:organization/o-different1",
+			expected: "o-different1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orgId(&tt.arn)
+			if got != tt.expected {
+				t.Errorf("orgId(%q) = %q, want %q", tt.arn, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateShareOrgIds(t *testing.T) {
+	tests := []struct {
+		name    string
+		ids     []string
+		wantErr bool
+	}{
+		{
+			name: "reviewer case: same org ID different management accounts",
+			ids: []string{
+				"arn:aws:organizations::329260820478:organization/o-meltunc7lj",
+				"arn:aws:organizations::329260824578:organization/o-meltunc7lj",
+			},
+			wantErr: true,
+		},
+		{
+			name: "exact duplicate org ARN",
+			ids: []string{
+				"arn:aws:organizations::329260820478:organization/o-meltunc7lj",
+				"arn:aws:organizations::329260820478:organization/o-meltunc7lj",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "exact duplicate plain account ID",
+			ids:     []string{"851725220677", "851725220677"},
+			wantErr: true,
+		},
+		{
+			name: "two org ARNs with different org IDs",
+			ids: []string{
+				"arn:aws:organizations::329260820478:organization/o-meltunc7lj",
+				"arn:aws:organizations::329260820478:organization/o-different1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "two account-level ARNs same org different accounts",
+			ids: []string{
+				"arn:aws:organizations::329260820478:account/o-melcpnc7lj/851725220677",
+				"arn:aws:organizations::329260820478:account/o-melcpnc7lj/585132637328",
+			},
+			wantErr: false,
+		},
+		{
+			name: "two OU ARNs with different OU IDs",
+			ids: []string{
+				"arn:aws:organizations::329260820478:ou/o-melcpnc7lj/ou-aaaa-11111111",
+				"arn:aws:organizations::329260820478:ou/o-melcpnc7lj/ou-bbbb-22222222",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty list",
+			ids:     []string{},
+			wantErr: false,
+		},
+		{
+			name:    "single entry",
+			ids:     []string{"arn:aws:organizations::329260820478:organization/o-meltunc7lj"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateShareOrgIds(tt.ids)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateShareOrgIds(%v) error = %v, wantErr %v", tt.ids, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/provider/aws/ami_test.go
+++ b/pkg/provider/aws/ami_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func TestOrgId(t *testing.T) {
+func TestPulumiResourceId(t *testing.T) {
 	tests := []struct {
 		name     string
 		arn      string
@@ -37,11 +37,21 @@ func TestOrgId(t *testing.T) {
 			arn:      "arn:aws:organizations::329260820478:ou/o-melcpnc7lj/ou-xxxx-yyyyyyyy",
 			expected: "o-melcpnc7lj-ou-xxxx-yyyyyyyy",
 		},
+		{
+			name:     "malformed ARN too few segments returns ARN as-is (no panic)",
+			arn:      "arn:aws:organizations::329260820478",
+			expected: "arn:aws:organizations::329260820478",
+		},
+		{
+			name:     "malformed ARN resource part has no slash returns ARN as-is (no panic)",
+			arn:      "arn:aws:organizations::329260820478:organization",
+			expected: "arn:aws:organizations::329260820478:organization",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := orgId(&tt.arn)
+			got := pulumiResourceId(tt.arn)
 			if got != tt.expected {
 				t.Errorf("orgId(%q) = %q, want %q", tt.arn, got, tt.expected)
 			}
@@ -51,12 +61,12 @@ func TestOrgId(t *testing.T) {
 
 // TestOrgIdUniqueness verifies that two account ARNs from the same org produce
 // distinct resource name suffixes (the root cause of issue #82).
-func TestOrgIdUniqueness(t *testing.T) {
+func TestPulumiResourceIdUniqueness(t *testing.T) {
 	arn1 := "arn:aws:organizations::329260820478:account/o-melcpnc7lj/851725220677"
 	arn2 := "arn:aws:organizations::329260820478:account/o-melcpnc7lj/585132637328"
 
-	id1 := orgId(&arn1)
-	id2 := orgId(&arn2)
+	id1 := pulumiResourceId(arn1)
+	id2 := pulumiResourceId(arn2)
 
 	if id1 == id2 {
 		t.Errorf("two account ARNs from the same org produced the same ID %q — would cause duplicate Pulumi URN", id1)
@@ -111,7 +121,7 @@ func TestLaunchPermArgs(t *testing.T) {
 	}
 }
 
-func TestOrgIdOrgLevel(t *testing.T) {
+func TestPulumiResourceIdOrgLevel(t *testing.T) {
 	tests := []struct {
 		name     string
 		arn      string
@@ -135,7 +145,7 @@ func TestOrgIdOrgLevel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := orgId(&tt.arn)
+			got := pulumiResourceId(tt.arn)
 			if got != tt.expected {
 				t.Errorf("orgId(%q) = %q, want %q", tt.arn, got, tt.expected)
 			}

--- a/pkg/provider/aws/ami_test.go
+++ b/pkg/provider/aws/ami_test.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func TestOrgId(t *testing.T) {
@@ -24,6 +26,11 @@ func TestOrgId(t *testing.T) {
 			name:     "second account-level ARN from same org returns different ID",
 			arn:      "arn:aws:organizations::329260820478:account/o-melcpnc7lj/585132637328",
 			expected: "o-melcpnc7lj-585132637328",
+		},
+		{
+			name:     "plain account ID returns account ID as-is",
+			arn:      "851725220677",
+			expected: "851725220677",
 		},
 		{
 			name:     "OU-level ARN returns ou compound ID",
@@ -53,5 +60,53 @@ func TestOrgIdUniqueness(t *testing.T) {
 
 	if id1 == id2 {
 		t.Errorf("two account ARNs from the same org produced the same ID %q — would cause duplicate Pulumi URN", id1)
+	}
+}
+
+func TestLaunchPermArgs(t *testing.T) {
+	imageId := pulumi.String("ami-12345678")
+
+	tests := []struct {
+		name        string
+		arn         string
+		wantOrgArn  bool
+		wantAcctId  bool
+		wantOUArn   bool
+	}{
+		{
+			name:       "org ARN routes to OrganizationArn",
+			arn:        "arn:aws:organizations::329260820478:organization/o-melcpnc7lj",
+			wantOrgArn: true,
+		},
+		{
+			name:       "account ARN routes to AccountId",
+			arn:        "arn:aws:organizations::329260820478:account/o-melcpnc7lj/851725220677",
+			wantAcctId: true,
+		},
+		{
+			name:       "plain account ID routes to AccountId",
+			arn:        "851725220677",
+			wantAcctId: true,
+		},
+		{
+			name:      "OU ARN routes to OrganizationalUnitArn",
+			arn:       "arn:aws:organizations::329260820478:ou/o-melcpnc7lj/ou-xxxx-yyyyyyyy",
+			wantOUArn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := launchPermArgs(imageId, tt.arn)
+			if got := args.OrganizationArn != nil; got != tt.wantOrgArn {
+				t.Errorf("OrganizationArn set=%v, want %v", got, tt.wantOrgArn)
+			}
+			if got := args.AccountId != nil; got != tt.wantAcctId {
+				t.Errorf("AccountId set=%v, want %v", got, tt.wantAcctId)
+			}
+			if got := args.OrganizationalUnitArn != nil; got != tt.wantOUArn {
+				t.Errorf("OrganizationalUnitArn set=%v, want %v", got, tt.wantOUArn)
+			}
+		})
 	}
 }

--- a/pkg/provider/aws/util.go
+++ b/pkg/provider/aws/util.go
@@ -96,8 +96,8 @@ func uploadDisk(ctx *pulumi.Context, rawImageFilePath, bucketName *string,
 		},
 		pulumi.Timeouts(
 			&pulumi.CustomTimeouts{
-				Create: "90m",
-				Update: "90m",
+				Create: "6h",
+				Update: "6h",
 				Delete: "90m"}),
 		pulumi.DependsOn(dependecies))
 }

--- a/pkg/provider/azure/image.go
+++ b/pkg/provider/azure/image.go
@@ -33,6 +33,8 @@ var (
 	outBlobURI          = "blobURI"
 )
 
+func (a *azureProvider) ValidateShareTargets(_ []string) error { return nil }
+
 func (a *azureProvider) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error) {
 	name, ok := ephemeralResults.Outputs[outName]
 	if !ok {


### PR DESCRIPTION
Fixes #82

## Problem

When `--share-orgs-ids` contains two or more account-level ARNs from the same org, the tool crashed with a duplicate Pulumi URN error. The resource name suffix helper extracted only the org ID segment from every ARN, producing the same suffix for all accounts in that org.

Additionally, account-level ARNs were always passed to the `OrganizationArn` field of `AmiLaunchPermission`, which AWS rejects — account-level sharing requires the `AccountId` field (plain 12-digit number).

## Changes

### `pkg/manager/provider/api/api.go`

- **`ValidateShareTargets(shareOrgIds []string) error` (new)**: Added to the `Provider` interface so share target validation is part of the provider contract.

### `pkg/manager/manager.go`

- **`RHELAI()` and `SNC()`**: Call `p.ValidateShareTargets()` before the upload begins, so invalid share targets are caught immediately rather than after a potentially hours-long image upload.

### `pkg/provider/aws/ami.go`

- **`pulumiResourceId()` (renamed from `orgId()`)**: Clarifies that this function generates a Pulumi resource name suffix only — it is never sent to AWS. The original ARN is forwarded unchanged via `launchPermArgs`. The function joins all path segments after the ARN resource type with `-`, making suffixes unique per share target. Also adds bounds checks to prevent index-out-of-range panics on malformed ARNs; malformed inputs are returned as-is and surface an error at the Pulumi or AWS layer.

  Accepted input forms and their Pulumi suffix output:

  | Input | Suffix |
  |---|---|
  | `851725220677` (plain account ID) | `851725220677` |
  | `arn:aws:organizations::MGMT:organization/o-xxx` | `o-xxx` |
  | `arn:aws:organizations::MGMT:account/o-xxx/ACCT_ID` | `o-xxx-ACCT_ID` |
  | `arn:aws:organizations::MGMT:ou/o-xxx/ou-yyy-zzz` | `o-xxx-ou-yyy-zzz` |

  Note: MGMT is intentionally excluded from the suffix. An AWS organization has exactly one management account, so two org ARNs with the same org ID but different MGMT values represent the same AWS target (one MGMT value must be wrong). Excluding MGMT means `validateShareOrgIds` correctly identifies such pairs as duplicates and returns a clear error rather than silently creating two Pulumi resources and letting AWS reject the one with the bad MGMT.

- **`launchPermArgs()` (new)**: Routes each share target to the correct `AmiLaunchPermissionArgs` field based on ARN resource type:
  - `organization/…` → `OrganizationArn`
  - `ou/…` → `OrganizationalUnitArn`
  - `account/…` → `AccountId` (extracts the trailing account number)
  - plain 12-digit ID → `AccountId` directly

- **`validateShareOrgIds()` (new)**: Called from `ValidateShareTargets` and also retained inside `ImageRegister` as defence-in-depth. Detects duplicate share targets using `pulumiResourceId` as the key and returns a clear error instead of a cryptic Pulumi URN crash. Works on both create and update paths.

  **Known limitation:** a plain account ID (e.g. `851725220677`) and a full account-level ARN for the same account (e.g. `arn:aws:organizations::MGMT:account/o-xxx/851725220677`) produce different keys and are not detected as duplicates. Normalising across those formats would require an `organizations:DescribeAccount` lookup that may not be available to the caller.

- **`ValidateShareTargets()` (new)**: AWS provider implementation — thin wrapper over `validateShareOrgIds`.

### `pkg/provider/azure/image.go`

- **`ValidateShareTargets()` (new)**: No-op implementation to satisfy the `Provider` interface; Azure tenant ID validation is not currently performed.

### `pkg/provider/aws/ami_test.go` (new)

18 unit tests covering:

**`pulumiResourceId()` suffix generation** — one case per accepted input format, plus:
- Two cases documenting malformed ARN handling (no panic, returned as-is)
- Org ARN with a different management account but same org ID → same suffix `o-xxx` (documents that these are the same AWS target; `validateShareOrgIds` catches this as a duplicate)

**`TestPulumiResourceIdUniqueness`** — explicit regression for issue #82: two account-level ARNs from the same org with different account IDs produce distinct suffixes, preventing the duplicate Pulumi URN crash.

**`launchPermArgs()` field routing** — one case per ARN type.

**`validateShareOrgIds()` input validation:**
- Reviewer's failing case — same org ID, different management accounts → error:
  ```
  arn:aws:organizations::329260820478:organization/o-meltunc7lj
  arn:aws:organizations::329260824578:organization/o-meltunc7lj
  ```
  These two ARNs cannot both be valid: an AWS organization has exactly one management account, so one of these management account IDs is wrong. Without this fix, the tool crashed at the Pulumi layer (duplicate URN) before reaching AWS. Even if that crash were avoided, AWS would have rejected whichever ARN carried the incorrect management account ID. The new validation catches the duplicate org ID at input time and returns a descriptive error, and now fires *before the upload begins* so the user gets immediate feedback.
- Exact duplicate org ARN → error
- Exact duplicate plain account ID → error
- Two org ARNs with different org IDs → ok
- Two account-level ARNs, same org, different accounts → ok
- Two OU ARNs with different OU IDs → ok
- Empty list → ok
- Single entry → ok

### `pkg/provider/aws/util.go`

Upload timeout increased from `90m` to `6h` to accommodate large images (RHEL AI raw images are ~57 GB).

## Test plan

- [x] Unit tests: `go test ./pkg/provider/aws/` — 18 tests, all pass
- [x] Build: `go build ./...` — clean
- [x] Reviewer's failing case — confirmed immediate failure with clear error, no upload started, no AWS credentials required:
  ```
  $ cloud-importer rhelai aws \
      --project-name test-issue-82 \
      --backed-url file:///tmp/test-issue-82-state \
      --image-path ~/cloud-importer-tests/rhel-ai-cuda-aws-3.4-ea.2-1776160181-x86_64.raw \
      --image-name test-issue-82 \
      --share-orgs-ids "arn:aws:organizations::329260820478:organization/o-meltunc7lj,arn:aws:organizations::329260824578:organization/o-meltunc7lj"

  Error: duplicate share target: "arn:aws:organizations::329260820478:organization/o-meltunc7lj" and "arn:aws:organizations::329260824578:organization/o-meltunc7lj" resolve to the same identifier "o-meltunc7lj" — check for duplicate entries or conflicting management account IDs in org ARNs
  ```
- [x] End-to-end: `rhelai aws` with `--share-orgs-ids "851725220677,585132637328"` (two accounts from the same org) — 5 resources created successfully, no duplicate URN crash, no AWS API rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)