### PR TITLE
feat(az): add progress monitoring for GalleryImageVersion creation

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -56,16 +56,17 @@ func RHELAI(ctx *context.ContextArgs,
 	if err != nil {
 		return err
 	}
-	registerFunc, err := p.ImageRegister(ephemeralResults,
+	registerFunc, progressMonitor, err := p.ImageRegister(ephemeralResults,
 		args.ImageControl.Replicate, args.ImageControl.ShareOrgIds)
 	if err != nil {
 		return err
 	}
 	registerStack := providerAPI.Stack{
-		ProjectName: context.ProjectName(),
-		StackName:   stackRHELAI,
-		BackedURL:   context.BackedURL(),
-		DeployFunc:  registerFunc}
+		ProjectName:     context.ProjectName(),
+		StackName:       stackRHELAI,
+		BackedURL:       context.BackedURL(),
+		DeployFunc:      registerFunc,
+		ProgressMonitor: progressMonitor}
 	_, err = upStack(registerStack)
 	if err != nil {
 		return err
@@ -102,16 +103,17 @@ func SNC(ctx *context.ContextArgs, args *SNCArgs, provider Provider) error {
 	if err != nil {
 		return err
 	}
-	registerFunc, err := p.ImageRegister(ephemeralResults,
+	registerFunc, progressMonitor, err := p.ImageRegister(ephemeralResults,
 		args.ImageControl.Replicate, args.ImageControl.ShareOrgIds)
 	if err != nil {
 		return err
 	}
 	registerStack := providerAPI.Stack{
-		ProjectName: context.ProjectName(),
-		StackName:   stackSNC,
-		BackedURL:   context.BackedURL(),
-		DeployFunc:  registerFunc}
+		ProjectName:     context.ProjectName(),
+		StackName:       stackSNC,
+		BackedURL:       context.BackedURL(),
+		DeployFunc:      registerFunc,
+		ProgressMonitor: progressMonitor}
 	_, err = upStack(registerStack)
 	if err != nil {
 		return err

--- a/pkg/manager/provider/api/api.go
+++ b/pkg/manager/provider/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/mapt-oss/cloud-importer/pkg/manager/provider/credentials"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -12,6 +14,9 @@ type Stack struct {
 	BackedURL           string
 	DeployFunc          pulumi.RunFunc
 	ProviderCredentials credentials.ProviderCredentials
+	// ProgressMonitor, if set, is run in a goroutine for the duration of the
+	// stack update and cancelled when the update completes.
+	ProgressMonitor func(ctx context.Context)
 }
 
 type Provider interface {
@@ -22,8 +27,10 @@ type Provider interface {
 	// ValidateShareTargets checks share target identifiers for errors (e.g. duplicates)
 	// before any upload or resource creation begins. Returns an error if the targets are invalid.
 	ValidateShareTargets(shareOrgIds []string) error
-	// Register AMI and keep state
-	ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error)
+	// Register AMI and keep state.
+	// The returned ProgressMonitor (if non-nil) is run in a goroutine for the
+	// duration of the stack update to report long-running operation progress.
+	ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, func(ctx context.Context), error)
 	// Manage Provider Credentials
 	GetProviderCredentials(customCreds map[string]string) credentials.ProviderCredentials
 	// Check if an image with the given name exists

--- a/pkg/manager/util.go
+++ b/pkg/manager/util.go
@@ -52,7 +52,16 @@ func upStackTargets(targetStack providerAPI.Stack, targetURNs []string, opts ...
 	if len(targetURNs) > 0 {
 		mOpts = append(mOpts, optup.Target(targetURNs))
 	}
+	var cancelMonitor context.CancelFunc
+	if targetStack.ProgressMonitor != nil {
+		var monitorCtx context.Context
+		monitorCtx, cancelMonitor = context.WithCancel(ctx)
+		go targetStack.ProgressMonitor(monitorCtx)
+	}
 	r, err := objectStack.Up(ctx, mOpts...)
+	if cancelMonitor != nil {
+		cancelMonitor()
+	}
 	if err != nil {
 		logging.Error(err)
 		if len(opts) == 1 && opts[0].Baground {

--- a/pkg/provider/aws/ami.go
+++ b/pkg/provider/aws/ami.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	gocontext "context"
 	"fmt"
 	"strings"
 
@@ -24,25 +25,25 @@ func (a *aws) ValidateShareTargets(shareOrgIds []string) error {
 	return validateShareOrgIds(shareOrgIds)
 }
 
-func (a *aws) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error) {
+func (a *aws) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, func(gocontext.Context), error) {
 	if err := validateShareOrgIds(shareOrgIds); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	amiNameOutput, ok := ephemeralResults.Outputs[outAMIName]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outAMIName)
+		return nil, nil, fmt.Errorf("output not found: %s", outAMIName)
 	}
 	amiArchOutput, ok := ephemeralResults.Outputs[outAMIArch]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outAMIArch)
+		return nil, nil, fmt.Errorf("output not found: %s", outAMIArch)
 	}
 	bucketNameOutput, ok := ephemeralResults.Outputs[outBucketName]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outBucketName)
+		return nil, nil, fmt.Errorf("output not found: %s", outBucketName)
 	}
 	roleNameOputput, ok := ephemeralResults.Outputs[outRoleName]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outRoleName)
+		return nil, nil, fmt.Errorf("output not found: %s", outRoleName)
 	}
 	r := registerRequest{
 		name:         amiNameOutput.Value.(string),
@@ -52,7 +53,7 @@ func (a *aws) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shar
 		replicate:    replicate,
 		shareorgARNs: shareOrgIds,
 	}
-	return r.registerFunc, nil
+	return r.registerFunc, nil, nil
 }
 
 type registerRequest struct {

--- a/pkg/provider/azure/image.go
+++ b/pkg/provider/azure/image.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	imgctx "github.com/mapt-oss/cloud-importer/pkg/manager/context"
+	"github.com/mapt-oss/cloud-importer/pkg/util/logging"
 	"github.com/pulumi/pulumi-azure-native-sdk/compute/v3"
 	resources "github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 
@@ -35,10 +38,10 @@ var (
 
 func (a *azureProvider) ValidateShareTargets(_ []string) error { return nil }
 
-func (a *azureProvider) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, error) {
+func (a *azureProvider) ImageRegister(ephemeralResults auto.UpResult, replicate bool, shareOrgIds []string) (pulumi.RunFunc, func(ctx context.Context), error) {
 	name, ok := ephemeralResults.Outputs[outName]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outName)
+		return nil, nil, fmt.Errorf("output not found: %s", outName)
 	}
 	rgName, ok := ephemeralResults.Outputs[outRgName]
 	if !ok {
@@ -46,27 +49,27 @@ func (a *azureProvider) ImageRegister(ephemeralResults auto.UpResult, replicate 
 	}
 	arch, ok := ephemeralResults.Outputs[outArch]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outArch)
+		return nil, nil, fmt.Errorf("output not found: %s", outArch)
 	}
 	offer, ok := ephemeralResults.Outputs[outOffer]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outOffer)
+		return nil, nil, fmt.Errorf("output not found: %s", outOffer)
 	}
 	publisher, ok := ephemeralResults.Outputs[outPublisher]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outPublisher)
+		return nil, nil, fmt.Errorf("output not found: %s", outPublisher)
 	}
 	sku, ok := ephemeralResults.Outputs[outSKU]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outSKU)
+		return nil, nil, fmt.Errorf("output not found: %s", outSKU)
 	}
 	saId, ok := ephemeralResults.Outputs[outServiceAccountId]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outServiceAccountId)
+		return nil, nil, fmt.Errorf("output not found: %s", outServiceAccountId)
 	}
 	blobURI, ok := ephemeralResults.Outputs[outBlobURI]
 	if !ok {
-		return nil, fmt.Errorf("output not found: %s", outBlobURI)
+		return nil, nil, fmt.Errorf("output not found: %s", outBlobURI)
 	}
 	r := regiterRequest{
 		rgName:           rgName.Value.(string),
@@ -80,7 +83,10 @@ func (a *azureProvider) ImageRegister(ephemeralResults auto.UpResult, replicate 
 		replicate:        replicate,
 		shareTenantIds:   shareOrgIds,
 	}
-	return r.registerFunc, nil
+	galleryName := strings.ReplaceAll(r.name, "-", "_")
+	return r.registerFunc, func(ctx context.Context) {
+		r.monitorGalleryImageVersionProgress(ctx, galleryName)
+	}, nil
 }
 
 type regiterRequest struct {
@@ -200,6 +206,56 @@ func (r *regiterRequest) registerFunc(ctx *pulumi.Context) error {
 		})
 	}
 	return err
+}
+
+func (r *regiterRequest) monitorGalleryImageVersionProgress(ctx context.Context, galleryName string) {
+	time.Sleep(30 * time.Second)
+	cred, subscriptionID, err := getCredentials()
+	if err != nil {
+		return
+	}
+	client, err := armcompute.NewGalleryImageVersionsClient(*subscriptionID, cred, nil)
+	if err != nil {
+		return
+	}
+	expand := armcompute.ReplicationStatusTypesReplicationStatus
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			resp, err := client.Get(ctx, r.rgName, galleryName, r.name, "1.0.0",
+				&armcompute.GalleryImageVersionsClientGetOptions{Expand: &expand})
+			if err != nil {
+				logging.Debugf("GalleryImageVersion progress poll: %v", err)
+				continue
+			}
+			if resp.Properties == nil {
+				continue
+			}
+			if resp.Properties.ProvisioningState != nil {
+				logging.Infof("GalleryImageVersion progress: provisioning state = %s",
+					*resp.Properties.ProvisioningState)
+			}
+			if resp.Properties.ReplicationStatus != nil {
+				if resp.Properties.ReplicationStatus.AggregatedState != nil {
+					logging.Infof("GalleryImageVersion replication: aggregated state = %s",
+						*resp.Properties.ReplicationStatus.AggregatedState)
+				}
+				for _, summary := range resp.Properties.ReplicationStatus.Summary {
+					if summary != nil && summary.Region != nil && summary.State != nil {
+						progress := ""
+						if summary.Progress != nil {
+							progress = fmt.Sprintf(" (progress: %d%%)", *summary.Progress)
+						}
+						logging.Infof("  Region %s: %s%s", *summary.Region, *summary.State, progress)
+					}
+				}
+			}
+		}
+	}
 }
 
 func shareGallery(sharTenantIDs []string, rgName, galleryName, imageName string) error {


### PR DESCRIPTION
GalleryImageVersion creation can take 1+ hours with no output. A background goroutine now polls Azure every 60s and logs provisioning state and per-region replication progress.