### PR TITLE
feat(tkn): add Tekton task to destroy Azure images

### DIFF
--- a/tkn/destroy-azure.yaml
+++ b/tkn/destroy-azure.yaml
@@ -1,0 +1,102 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cloud-importer-destroy-azure
+  labels:
+    app.kubernetes.io/version: "1.0.0-dev"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, azure, rhelai
+    tekton.dev/displayName: "CloudImporter Destroy Azure"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This Task destroys an Azure image using the cloud-importer tool.
+  params:
+    - name: debug
+      description: run with debug logs
+    - name: id
+      description: identifier for the taskrun (image name used as project name)
+    - name: keep-state
+      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      default: "false"
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: secret-az-credentials
+      description: |
+        ocp secret holding the azure credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${name}
+        type: Opaque
+        data:
+          client_id: ${client_id}
+          client_secret: ${client_secret}
+          tenant_id: ${tenant_id}
+          subscription_id: ${subscription_id}
+          location: ${location}
+          storage_account: ${storage_account}
+          storage_key: ${storage_key}
+  steps:
+    - name: run-cloud-importer
+      image: ghcr.io/mapt-oss/cloud-importer:latest
+      script: |
+        #!/bin/sh
+
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
+        export ARM_CLIENT_SECRET=$(cat /opt/az-credentials/client_secret)
+        export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
+        export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
+        export ARM_LOCATION_NAME=$(cat /opt/az-credentials/location)
+        export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
+        export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
+
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "ARM_TENANT_ID=$ARM_TENANT_ID"
+          echo "ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID"
+          echo "ARM_LOCATION_NAME=$ARM_LOCATION_NAME"
+          echo "AZURE_STORAGE_ACCOUNT=$AZURE_STORAGE_ACCOUNT"
+          set -xeuo pipefail
+        fi
+
+        cmd="cloud-importer destroy "
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url azblob://aipcc-productization/cloud-importer "
+        if [[ "$(params.debug)" == "true" ]]; then
+          cmd+="--debug "
+        fi
+        if [[ "$(params.keep-state)" == "true" ]]; then
+          cmd+="--keep-state "
+        fi
+        if [[ "$(params.force-destroy)" == "true" ]]; then
+          cmd+="--force-destroy "
+        fi
+
+        eval ${cmd}
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/az-credentials
+  volumes:
+    - name: az-credentials
+      secret:
+        secretName: $(params.secret-az-credentials)


### PR DESCRIPTION
cloud-importer destroy is provider-agnostic; swapping the backed-url from s3:// to azblob:// is sufficient to target Azure. This task mirrors the existing AWS destroy pattern with Azure credentials (ARM_CLIENT_ID/SECRET/TENANT_ID/SUBSCRIPTION_ID, AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY) mounted from a secret and the Pulumi state backend hardcoded to azblob://aipcc-productization/cloud-importer.