### PR TITLE
fix(aws): use deterministic S3 bucket name for RHELAI ephemeral storage

### DIFF
--- a/pkg/provider/aws/rhelai.go
+++ b/pkg/provider/aws/rhelai.go
@@ -28,7 +28,7 @@ func (a *aws) RHELAIEphemeral(imageFilePath, imageName string) pulumi.RunFunc {
 func (r rhelaiEphemeralRequest) rhelaiEphemeralRunFunc(ctx *pulumi.Context) error {
 	ctx.Export(outAMIName, pulumi.String(r.amiName))
 	ctx.Export(outAMIArch, pulumi.String(rhelaiArch))
-	bucketName := randomID()
+	bucketName := stableBucketName(r.amiName)
 	b, err := bucketEphemeral(ctx, bucketName)
 	if err != nil {
 		return err

--- a/pkg/provider/aws/util.go
+++ b/pkg/provider/aws/util.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/mapt-oss/cloud-importer/pkg/manager/context"
+	"github.com/mapt-oss/cloud-importer/pkg/util"
 	awsnative "github.com/pulumi/pulumi-aws-native/sdk/go/aws"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/iam"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/s3"
@@ -47,25 +48,14 @@ func bucketEphemeral(ctx *pulumi.Context, bucketName *string) (*s3.Bucket, error
 // stableBucketName derives a deterministic S3 bucket name from the image name
 // so that retries with the same --image-name reuse the existing bucket rather
 // than triggering a Pulumi replace + re-upload (mirrors GCP's approach).
-// The "ci-" prefix ensures the name never starts with a digit.
+// The "tmp-" prefix marks it as ephemeral and ensures the name never starts with a digit.
 func stableBucketName(imageName string) *string {
-	name := "ci-" + sanitizeImageName(imageName)
+	name := "tmp-" + util.SanitizeBucketName(imageName)
 	if len(name) > 63 {
 		name = name[:63]
 	}
 	name = strings.TrimRight(name, "-")
 	return &name
-}
-
-// sanitizeImageName converts an image name to an S3-bucket-compatible format:
-// lowercase, only hyphens (no underscores/dots), max 63 chars.
-func sanitizeImageName(name string) string {
-	name = strings.ToLower(name)
-	name = strings.NewReplacer("_", "-", ".", "-").Replace(name)
-	if len(name) > 63 {
-		name = name[:63]
-	}
-	return strings.TrimRight(name, "-")
 }
 
 // https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html

--- a/pkg/provider/aws/util.go
+++ b/pkg/provider/aws/util.go
@@ -1,8 +1,8 @@
 package aws
 
 import (
-	"crypto/rand"
 	"fmt"
+	"strings"
 
 	"github.com/mapt-oss/cloud-importer/pkg/manager/context"
 	awsnative "github.com/pulumi/pulumi-aws-native/sdk/go/aws"
@@ -44,12 +44,28 @@ func bucketEphemeral(ctx *pulumi.Context, bucketName *string) (*s3.Bucket, error
 
 }
 
-// // random name for temporary assets required for importing the image
-func randomID() *string {
-	b := make([]byte, 4)
-	_, _ = rand.Read(b)
-	id := fmt.Sprintf("cloud-importer-%x", b)
-	return &id
+// stableBucketName derives a deterministic S3 bucket name from the image name
+// so that retries with the same --image-name reuse the existing bucket rather
+// than triggering a Pulumi replace + re-upload (mirrors GCP's approach).
+// The "ci-" prefix ensures the name never starts with a digit.
+func stableBucketName(imageName string) *string {
+	name := "ci-" + sanitizeImageName(imageName)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	name = strings.TrimRight(name, "-")
+	return &name
+}
+
+// sanitizeImageName converts an image name to an S3-bucket-compatible format:
+// lowercase, only hyphens (no underscores/dots), max 63 chars.
+func sanitizeImageName(name string) string {
+	name = strings.ToLower(name)
+	name = strings.NewReplacer("_", "-", ".", "-").Replace(name)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	return strings.TrimRight(name, "-")
 }
 
 // https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html

--- a/pkg/provider/aws/util_test.go
+++ b/pkg/provider/aws/util_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeImageName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"lowercase", "MyImage", "myimage"},
+		{"underscores to hyphens", "my_image_name", "my-image-name"},
+		{"dots to hyphens", "image.v1.2.3", "image-v1-2-3"},
+		{"mixed", "RHEL_AI.v1_2", "rhel-ai-v1-2"},
+		{"truncate at 63", strings.Repeat("a", 70), strings.Repeat("a", 63)},
+		{"trim trailing hyphens after truncation", strings.Repeat("a", 62) + "._", strings.Repeat("a", 62)},
+		{"already valid", "my-image-123", "my-image-123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeImageName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeImageName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if len(got) > 63 {
+				t.Errorf("sanitizeImageName(%q) length %d exceeds 63", tt.input, len(got))
+			}
+			if strings.HasSuffix(got, "-") {
+				t.Errorf("sanitizeImageName(%q) = %q: has trailing hyphen", tt.input, got)
+			}
+		})
+	}
+}
+
+func TestStableBucketName(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageName string
+		wantStart string
+	}{
+		{"adds ci- prefix", "rhelai-1.4-x86_64", "ci-rhelai-1-4-x86-64"},
+		{"same input same output", "rhelai-1.4", "ci-rhelai-1-4"},
+		{"uppercase lowercased", "RHELAI", "ci-rhelai"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stableBucketName(tt.imageName)
+			if *got != tt.wantStart {
+				t.Errorf("stableBucketName(%q) = %q, want %q", tt.imageName, *got, tt.wantStart)
+			}
+			if len(*got) > 63 {
+				t.Errorf("stableBucketName(%q) length %d exceeds 63", tt.imageName, len(*got))
+			}
+			if strings.HasSuffix(*got, "-") {
+				t.Errorf("stableBucketName(%q) = %q: has trailing hyphen", tt.imageName, *got)
+			}
+		})
+	}
+
+	t.Run("deterministic on repeated calls", func(t *testing.T) {
+		name := "rhelai-1.4-1-x86_64"
+		first := stableBucketName(name)
+		second := stableBucketName(name)
+		if *first != *second {
+			t.Errorf("stableBucketName(%q) not deterministic: %q vs %q", name, *first, *second)
+		}
+	})
+}

--- a/pkg/provider/aws/util_test.go
+++ b/pkg/provider/aws/util_test.go
@@ -5,46 +5,15 @@ import (
 	"testing"
 )
 
-func TestSanitizeImageName(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"lowercase", "MyImage", "myimage"},
-		{"underscores to hyphens", "my_image_name", "my-image-name"},
-		{"dots to hyphens", "image.v1.2.3", "image-v1-2-3"},
-		{"mixed", "RHEL_AI.v1_2", "rhel-ai-v1-2"},
-		{"truncate at 63", strings.Repeat("a", 70), strings.Repeat("a", 63)},
-		{"trim trailing hyphens after truncation", strings.Repeat("a", 62) + "._", strings.Repeat("a", 62)},
-		{"already valid", "my-image-123", "my-image-123"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeImageName(tt.input)
-			if got != tt.want {
-				t.Errorf("sanitizeImageName(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-			if len(got) > 63 {
-				t.Errorf("sanitizeImageName(%q) length %d exceeds 63", tt.input, len(got))
-			}
-			if strings.HasSuffix(got, "-") {
-				t.Errorf("sanitizeImageName(%q) = %q: has trailing hyphen", tt.input, got)
-			}
-		})
-	}
-}
-
 func TestStableBucketName(t *testing.T) {
 	tests := []struct {
 		name      string
 		imageName string
 		wantStart string
 	}{
-		{"adds ci- prefix", "rhelai-1.4-x86_64", "ci-rhelai-1-4-x86-64"},
-		{"same input same output", "rhelai-1.4", "ci-rhelai-1-4"},
-		{"uppercase lowercased", "RHELAI", "ci-rhelai"},
+		{"adds tmp- prefix", "rhelai-1.4-x86_64", "tmp-rhelai-1-4-x86-64"},
+		{"same input same output", "rhelai-1.4", "tmp-rhelai-1-4"},
+		{"uppercase lowercased", "RHELAI", "tmp-rhelai"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/azure/util.go
+++ b/pkg/provider/azure/util.go
@@ -3,11 +3,11 @@ package azure
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/mapt-oss/cloud-importer/pkg/manager/context"
+	"github.com/mapt-oss/cloud-importer/pkg/util"
 	resources "github.com/pulumi/pulumi-azure-native-sdk/resources/v3"
 	"github.com/pulumi/pulumi-azure-native-sdk/storage/v3"
 	"github.com/pulumi/pulumi-command/sdk/go/command/local"
@@ -47,18 +47,8 @@ func uploadVHD(ctx *pulumi.Context, vhdPath string, blobSASUrl pulumi.StringInpu
 	return err
 }
 
-func sanitizeName(input string) string {
-	re := regexp.MustCompile(`[^a-z0-9]`)
-	clean := re.ReplaceAllString(input, "")
-	if len(clean) > 24 {
-		clean = clean[:24]
-	}
-
-	return clean
-}
-
 func storageAccount(ctx *pulumi.Context, location, name *string) (*storage.BlobContainer, *storage.StorageAccount, *resources.ResourceGroup, error) {
-	ephemeralName := sanitizeName(*name)
+	ephemeralName := util.SanitizeStorageAccountName(*name)
 	resourceGroup, err := resources.NewResourceGroup(ctx,
 		"vhd",
 		&resources.ResourceGroupArgs{

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+func sanitize(name string, allowHyphens bool, maxLen int) string {
+	name = strings.ToLower(name)
+	if allowHyphens {
+		name = strings.NewReplacer("_", "-", ".", "-").Replace(name)
+		name = regexp.MustCompile(`[^a-z0-9-]`).ReplaceAllString(name, "")
+	} else {
+		name = regexp.MustCompile(`[^a-z0-9]`).ReplaceAllString(name, "")
+	}
+	if len(name) > maxLen {
+		name = name[:maxLen]
+	}
+	return strings.TrimRight(name, "-")
+}
+
+// SanitizeStorageAccountName produces a name valid for Azure storage accounts:
+// lowercase alphanumeric only (no hyphens), max 24 chars.
+func SanitizeStorageAccountName(name string) string {
+	return sanitize(name, false, 24)
+}
+
+// SanitizeBucketName produces a name valid for S3 and GCS buckets:
+// lowercase, hyphens allowed, max 63 chars.
+func SanitizeBucketName(name string) string {
+	return sanitize(name, true, 63)
+}

--- a/pkg/util/naming_test.go
+++ b/pkg/util/naming_test.go
@@ -1,0 +1,71 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeStorageAccountName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"lowercase", "MyStorage", "mystorage"},
+		{"strips hyphens", "my-storage", "mystorage"},
+		{"strips dots", "my.storage.v1", "mystoragev1"},
+		{"strips underscores", "my_storage", "mystorage"},
+		{"strips special chars", "my storage!@#", "mystorage"},
+		{"truncate at 24", strings.Repeat("a", 30), strings.Repeat("a", 24)},
+		{"already valid", "mystorage123", "mystorage123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeStorageAccountName(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeStorageAccountName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if len(got) > 24 {
+				t.Errorf("SanitizeStorageAccountName(%q) length %d exceeds 24", tt.input, len(got))
+			}
+			if strings.ContainsAny(got, "-_.") {
+				t.Errorf("SanitizeStorageAccountName(%q) = %q: contains invalid character", tt.input, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeBucketName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"lowercase", "MyBucket", "mybucket"},
+		{"underscores to hyphens", "my_bucket_name", "my-bucket-name"},
+		{"dots to hyphens", "bucket.v1.2.3", "bucket-v1-2-3"},
+		{"mixed", "RHEL_AI.v1_2", "rhel-ai-v1-2"},
+		{"strips special chars", "my bucket!@#", "mybucket"},
+		{"strips spaces", "my image v1", "myimagev1"},
+		{"truncate at 63", strings.Repeat("a", 70), strings.Repeat("a", 63)},
+		{"trim trailing hyphens after truncation", strings.Repeat("a", 62) + "._", strings.Repeat("a", 62)},
+		{"already valid", "my-bucket-123", "my-bucket-123"},
+		{"keeps hyphens", "my-image-name", "my-image-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeBucketName(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeBucketName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if len(got) > 63 {
+				t.Errorf("SanitizeBucketName(%q) length %d exceeds 63", tt.input, len(got))
+			}
+			if strings.HasSuffix(got, "-") {
+				t.Errorf("SanitizeBucketName(%q) = %q: has trailing hyphen", tt.input, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces \`randomID()\` with \`stableBucketName(imageName)\` in the AWS RHELAI ephemeral stack so re-runs with the same \`--image-name\` reuse the existing S3 bucket and skip the re-upload instead of creating a new bucket each time
- Lifts sanitization logic to \`pkg/util/naming.go\` with \`SanitizeBucketName\` (S3/GCS: hyphens ok, max 63) and \`SanitizeStorageAccountName\` (Azure: no hyphens, max 24) — AWS and Azure providers both delegate to these shared functions; GCP will follow when its branch merges
- Adds defensive regex stripping of any remaining invalid characters, closing the gap vs Azure's original implementation
- Uses \`tmp-\` prefix on S3 bucket names to make ephemeral intent clear; removes the now-unnecessary \`sanitizeName\` wrapper in Azure

Fixes #67.

## Test plan

- [x] Unit tests for \`SanitizeBucketName\` and \`SanitizeStorageAccountName\` in \`pkg/util/naming_test.go\`
- [x] Unit tests for \`stableBucketName\` in \`pkg/provider/aws/util_test.go\`
- [x] E2E AWS: ran \`rhelai aws\` twice with the same \`--image-name\`; first run created bucket \`tmp-rhelai-test-issue67\` and uploaded in ~1m15s; second run completed ephemeral stack in **33s with 5 unchanged** — bucket and upload reused, no new bucket created
- [x] E2E Azure: ran \`rhelai az\` and confirmed storage account name \`rhelaitestissue67az\` (hyphens stripped, correct max-24 truncation) via \`pkg/util/naming.go\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)