### PR TITLE
fix: CI failures in PR #90 — go-toolset builder image and aws-native v8 IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ export GOOGLE_CREDENTIALS=$(bw get notes "GCP_SA_KEY" | jq -c .)  # compact mult
 
 ### Run with local Pulumi state
 
+**AWS:**
 ```bash
 podman run --rm --name import-rhelai -d \
     --user 0 \
@@ -386,7 +387,47 @@ podman run --rm --name import-rhelai -d \
 podman logs -f import-rhelai
 ```
 
-Replace `aws` with `az` or `gcp` and swap the `-e` flags to match the provider. Pulumi state is written to `${PWD}/rhelai-dev-test/` — delete it when done.
+**GCP:**
+```bash
+podman run --rm --name import-rhelai-gcp -d \
+    --user 0 \
+    -v ${PWD}:/workspace:z \
+    -e GOOGLE_PROJECT \
+    -e GOOGLE_CREDENTIALS \
+    -e GOOGLE_REGION \
+    quay.io/aipcc-cicd/cloud-importer:latest rhelai gcp \
+        --project-name "rhelai-dev-test" \
+        --backed-url "file:///workspace" \
+        --image-name "rhelai-dev-test" \
+        --image-path "/workspace/disk.raw" \
+        --debug \
+        --debug-level 9
+
+podman logs -f import-rhelai-gcp
+```
+
+**Azure:**
+```bash
+podman run --rm --name import-rhelai-azure -d \
+    --user 0 \
+    -v ${PWD}:/workspace:z \
+    -e ARM_TENANT_ID \
+    -e ARM_CLIENT_ID \
+    -e ARM_CLIENT_SECRET \
+    -e ARM_SUBSCRIPTION_ID \
+    -e ARM_LOCATION_NAME \
+    quay.io/aipcc-cicd/cloud-importer:latest rhelai az \
+        --project-name "rhelai-dev-test" \
+        --backed-url "file:///workspace" \
+        --image-name "rhelai-dev-test" \
+        --image-path "/workspace/rhel-ai-nvidia-aws-1.5-x86_64.vhd" \
+        --debug \
+        --debug-level 9
+
+podman logs -f import-rhelai-azure
+```
+
+Pulumi state is written to `${PWD}/rhelai-dev-test/` — you can delete it when you are done, after you have cleaned up any images you uploaded as part of the test.
 
 ### Run with a cloud Pulumi state backend
 
@@ -410,7 +451,7 @@ PULUMI_CONFIG_PASSPHRASE="" /path/to/importer rhelai gcp \
 
 ## Testing VMs
 
-After a successful import, launch a short-lived test VM to confirm the image boots correctly and is the expected OS/version. Remember to delete the test VM when done.
+After a successful import, the following commands show how to launch a short-lived test VM to confirm the image boots correctly and is the expected OS/version. The region you run the VM in must have access to the image and will benefit from having default networking already established — if it doesn't, you will need to create or configure the necessary networking yourself. Remember to delete the test VM when done.
 
 ### AWS
 

--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:8b211cc8793d8013140844e8070aa584a8eb3e4e6e842ea4b03dd9914b1a5dc6 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:75ecb48dfaec6655bd589091902e3b9328c300befba34cb06fc5e7323099e17d as builder
 
 ARG TARGETARCH
 USER root

--- a/pkg/provider/aws/rhelai.go
+++ b/pkg/provider/aws/rhelai.go
@@ -54,7 +54,7 @@ func (r rhelaiEphemeralRequest) rhelaiEphemeralRunFunc(ctx *pulumi.Context) erro
 	if err != nil {
 		return err
 	}
-	ro, _, err := createVMIEmportExportRole(ctx, bucketName)
+	ro, err := createVMIEmportExportRole(ctx, bucketName)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/snc.go
+++ b/pkg/provider/aws/snc.go
@@ -52,7 +52,7 @@ func (r sncEphemeralRequest) sncEphemeralRunFunc(ctx *pulumi.Context) error {
 		return err
 	}
 	ctx.Export(outBucketName, pulumi.String(*bucketName))
-	ro, _, err := createVMIEmportExportRole(ctx, bucketName)
+	ro, err := createVMIEmportExportRole(ctx, bucketName)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/util.go
+++ b/pkg/provider/aws/util.go
@@ -60,25 +60,20 @@ func stableBucketName(imageName string) *string {
 
 // https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html
 func createVMIEmportExportRole(ctx *pulumi.Context,
-	roleName *string) (*iam.Role, pulumi.Resource, error) {
-	role, err := iam.NewRole(ctx,
+	roleName *string) (*iam.Role, error) {
+	return iam.NewRole(ctx,
 		"role",
 		&iam.RoleArgs{
 			RoleName:                 pulumi.String(*roleName),
 			AssumeRolePolicyDocument: pulumi.Any(trustPolicyContent()),
-			Tags:                     getTags(),
+			Policies: iam.RolePolicyTypeArray{
+				iam.RolePolicyTypeArgs{
+					PolicyName:     pulumi.String("vmimport-policy"),
+					PolicyDocument: pulumi.Any(rolePolicyContent(*roleName)),
+				},
+			},
+			Tags: getTags(),
 		})
-	if err != nil {
-		return nil, nil, err
-	}
-	rolePolicyAttachment, err := iam.NewRolePolicy(ctx,
-		"rolePolicy",
-		&iam.RolePolicyArgs{
-			RoleName: role.ID(),
-			PolicyDocument: pulumi.Any(
-				rolePolicyContent(*roleName)),
-		})
-	return role, rolePolicyAttachment, err
 }
 
 func uploadDisk(ctx *pulumi.Context, rawImageFilePath, bucketName *string,


### PR DESCRIPTION
## Summary

- **CI fix**: Update `oci/Containerfile` builder from Go 1.25.7 to Go 1.25.8 — `go.mod` requires `go 1.25.8` but the pinned `ubi9/go-toolset` digest resolved to 1.25.7, causing CI build failures in PR #90
- **aws-native v6→v8 fix**: `iam.NewRolePolicy` (separate resource) caused `[diff: -policies]` on role update, stripping inline policies from the IAM role. Fixed by embedding the policy directly in `iam.NewRole` via the `Policies` field
- **docs**: Add developer testing examples using personal state backends (buckets) to avoid polluting `aipcc-productization`

## Test plan

- [x] GCP full cycle: import → check (READY) → destroy — confirmed working
- [x] AWS full cycle: import → check → AMI deregistered → destroy — confirmed working (IAM policy fix validated)
- [x] Azure full cycle: import → Gallery/GalleryImage/GalleryImageVersion created → destroy — confirmed working
- [x] Container builds successfully with Go 1.25.8 builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)