### PR TITLE
feat(tkn): overhaul Tekton tasks with operation param, secrets, and G…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ define tkn_update
 	rm -f tkn/*.yaml
 	sed -e 's%<IMAGE>%$(1)%g' -e 's%<VERSION>%$(2)%g' tkn/template/rhelai-aws.yaml > tkn/rhelai-aws.yaml
 	sed -e 's%<IMAGE>%$(1)%g' -e 's%<VERSION>%$(2)%g' tkn/template/rhelai-azure.yaml > tkn/rhelai-azure.yaml
+	sed -e 's%<IMAGE>%$(1)%g' -e 's%<VERSION>%$(2)%g' tkn/template/rhelai-gcp.yaml > tkn/rhelai-gcp.yaml
 	sed -e 's%<IMAGE>%$(1)%g' -e 's%<VERSION>%$(2)%g' tkn/template/snc-aws.yaml > tkn/snc-aws.yaml
 	sed -e 's%<IMAGE>%$(1)%g' -e 's%<VERSION>%$(2)%g' tkn/template/snc-azure.yaml > tkn/snc-azure.yaml
 endef

--- a/tkn/rhelai-aws.yaml
+++ b/tkn/rhelai-aws.yaml
@@ -14,30 +14,59 @@ spec:
   description: >-
     This Task imports a RAW image to AWS using the cloud-importer tool.
   params:
-    - name: raw-image-path
-      description: Local path to the raw image.
-    - name: ami-name
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the AWS credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+
+    # uploading of images
+    - name: image-name
       description: The name of the AMI to be created.
-    - name: share-with-account-ids
-      description: "A comma-separated list of account IDs to share the AMI with."
       default: ""
+    - name: image-path
+      description: Local path to the raw image.
+      default: ""
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the AMI to."
+      default: "all"
     - name: share-orgs-ids
       description: "A comma-separated list of organization ARNs to share the AMI with."
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
-      default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
+    - name: tags
+      description: "A comma-separated list of tags to add to the AMI."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the S3 backend after successful destroy
+      default: "false"
   workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/aws-credentials
     - name: data
       description: A workspace for the raw image.
       mountPath: /data
+      optional: true
   steps:
     - name: run-cloud-importer
       image: quay.io/aipcc-cicd/cloud-importer:v1.0.0-dev
@@ -72,19 +101,52 @@ spec:
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer rhelai aws --output /data/output.json --image-path /data/$(params.raw-image-path) "
-        cmd+="--image-name $(params.ami-name) "
-        cmd+="--backed-url s3://${BUCKET}/cloud-importer/$(params.id) "
-        if [[ "$(params.debug)" == "true" ]]; then
-          cmd+="--debug"
-        fi
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+=" --share-orgs-ids=$(params.share-orgs-ids)"
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          if [[ "$(workspaces.data.bound)" != "true" ]]; then
+            echo "ERROR: workspace 'data' must be bound for create operation"
+            exit 1
+          fi
+          cmd+="rhelai aws "
+          cmd+="--image-path /data/$(params.image-path) "
+          cmd+="--image-name $(params.image-name) "
+
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+=" --replicate=$(params.replicate-to-regions)"
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/cloud-importer "
+
+        if [[ "$(params.debug)" == "true" ]]; then
+          cmd+="--debug "
         fi
 
         eval ${cmd}
 
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)

--- a/tkn/rhelai-azure.yaml
+++ b/tkn/rhelai-azure.yaml
@@ -14,27 +14,63 @@ spec:
   description: >-
     This Task imports a RAW image to Azure using the cloud-importer tool.
   params:
-    - name: raw-image-path
-      description: Local path to the raw image.
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-az-credentials
+      description: |
+        K8S secret holding the Azure credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: azure-${name}
+        type: Opaque
+        data:
+          blob: ${blob}
+          client-id: ${client_id}
+          client-secret: ${client_secret}
+          location: ${location}
+          storage-account: ${storage_account}
+          storage-key: ${storage_key}
+          subscription-id: ${subscription_id}
+          tenant-id: ${tenant_id}
+
+    # uploading of images
     - name: image-name
       description: The name for the image in Azure.
-    - name: replicate-to-regions
+      default: ""
+    - name: image-path
+      description: Local path to the vhd image.
+      default: ""
+    - name: replicate
       description: "A comma-separated list of regions to replicate the image to."
       default: "all"
     - name: share-orgs-ids
-      description: "A comma-separated list of organization ARNs to share the AMI with."
+      description: "A comma-separated list of organization tenant IDs to share the image with."
       default: ""
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
+    - name: tags
+      description: "A comma-separated list of tags to add to the image."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      default: "false"
   workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/azure-credentials
     - name: data
-      description: A workspace for the raw image.
+      description: A workspace for the vhd image.
       mountPath: /data
+      optional: true
   steps:
     - name: run-cloud-importer
       image: quay.io/aipcc-cicd/cloud-importer:v1.0.0-dev
@@ -55,35 +91,74 @@ spec:
         }
 
         # Credentials - set these BEFORE enabling debug mode
-        export AZURE_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
-        export AZURE_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
-        export AZURE_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
-        export AZURE_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
-        export AZURE_STORAGE_ACCOUNT_NAME=$(cat /opt/azure-credentials/storage-account)
-
+        export AZURE_STORAGE_ACCOUNT=$(cat /opt/azure-credentials/storage-account)
+        export AZURE_STORAGE_KEY=$(cat /opt/azure-credentials/storage-key)
+        export ARM_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
+        export ARM_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
+        export ARM_LOCATION_NAME=$(cat /opt/azure-credentials/location)
+        export ARM_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
+        export ARM_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
+        BLOB=$(cat /opt/azure-credentials/blob)
 
         # If debug add verbosity and print masked credentials
         if [[ "$(params.debug)" == "true" ]]; then
-          echo "AZURE_CLIENT_ID=$(mask_credential "$AZURE_CLIENT_ID")"
-          echo "AZURE_CLIENT_SECRET=$(mask_credential "$AZURE_CLIENT_SECRET")"
-          echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
-          echo "AZURE_SUBSCRIPTION_ID"=$AZURE_SUBSCRIPTION_ID
-          echo "AZURE_STORAGE_ACCOUNT_NAME"=$AZURE_STORAGE_ACCOUNT_NAME
+          echo "AZURE_STORAGE_ACCOUNT"=$(mask_credential "$AZURE_STORAGE_ACCOUNT")
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "ARM_LOCATION_NAME"=$ARM_LOCATION_NAME
+          echo "ARM_SUBSCRIPTION_ID"=$(mask_credential "$ARM_SUBSCRIPTION_ID")
+          echo "ARM_TENANT_ID"=$(mask_credential "$ARM_TENANT_ID")
+          echo "BLOB"=$BLOB
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer rhelai az --output /data/output.json --image-path /data/$(params.raw-image-path) "
-        cmd+="--image-name $(params.image-name) "
-        cmd+="--backed-url azblob://${AZURE_STORAGE_ACCOUNT_NAME}/cloud-importer/$(params.id) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          if [[ "$(workspaces.data.bound)" != "true" ]]; then
+            echo "ERROR: workspace 'data' must be bound for create operation"
+            exit 1
+          fi
+          cmd+="rhelai az "
+          cmd+="--image-path /data/$(params.image-path) "
+          cmd+="--image-name $(params.image-name) "
+
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
+        fi
+
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url azblob://${BLOB}/cloud-importer "
+
         if [[ "$(params.debug)" == "true" ]]; then
-          cmd+="--debug"
-        fi
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+=" --replicate=$(params.replicate-to-regions)"
-        fi
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+=" --replicate=$(params.share-orgs-ids)"
+          cmd+="--debug "
         fi
 
         eval ${cmd}
 
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/az-credentials
+  volumes:
+    - name: az-credentials
+      secret:
+        secretName: $(params.secret-az-credentials)

--- a/tkn/rhelai-gcp.yaml
+++ b/tkn/rhelai-gcp.yaml
@@ -1,18 +1,18 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: cloud-importer-azure
+  name: cloud-importer-rhelai-gcp
   labels:
-    app.kubernetes.io/version: "<VERSION>"
+    app.kubernetes.io/version: "1.0.0-dev"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/categories: infrastructure
-    tekton.dev/tags: infrastructure, azure, rhelai
-    tekton.dev/displayName: "CloudImporter Azure"
+    tekton.dev/tags: infrastructure, gcp, rhelai
+    tekton.dev/displayName: "CloudImporter RHEL-AI GCP"
     tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
-    This Task imports a RAW image to Azure using the cloud-importer tool.
+    This Task imports a RAW image to GCP using the cloud-importer tool.
   params:
     # general
     - name: debug
@@ -22,32 +22,28 @@ spec:
     - name: operation
       description: operation to perform (create or destroy)
       default: create
-    - name: secret-az-credentials
+    - name: secret-gcp-credentials
       description: |
-        K8S secret holding the Azure credentials. Secret should be accessible to this task.
+        K8S secret holding the GCP credentials. Secret should be accessible to this task.
 
         ---
         apiVersion: v1
         kind: Secret
         metadata:
-          name: azure-${name}
+          name: gcp-${name}
         type: Opaque
         data:
-          blob: ${blob}
-          client-id: ${client_id}
-          client-secret: ${client_secret}
-          location: ${location}
-          storage-account: ${storage_account}
-          storage-key: ${storage_key}
-          subscription-id: ${subscription_id}
-          tenant-id: ${tenant_id}
+          bucket: ${bucket}
+          credentials: ${credentials}
+          project: ${project}
+          region: ${region}
 
     # uploading of images
     - name: image-name
-      description: The name for the image in Azure.
+      description: The name of the image to be created.
       default: ""
     - name: image-path
-      description: Local path to the vhd image.
+      description: Local path to the raw image.
       default: ""
     - name: replicate
       description: "A comma-separated list of regions to replicate the image to."
@@ -64,16 +60,16 @@ spec:
       description: destroy even if there is a lock
       default: "false"
     - name: keep-state
-      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      description: keep the Pulumi state in the GCS backend after successful destroy
       default: "false"
   workspaces:
     - name: data
-      description: A workspace for the vhd image.
+      description: A workspace for the raw image.
       mountPath: /data
       optional: true
   steps:
     - name: run-cloud-importer
-      image: <IMAGE>
+      image: quay.io/aipcc-cicd/cloud-importer:v1.0.0-dev
       script: |
         #!/bin/sh
 
@@ -91,25 +87,17 @@ spec:
         }
 
         # Credentials - set these BEFORE enabling debug mode
-        export AZURE_STORAGE_ACCOUNT=$(cat /opt/azure-credentials/storage-account)
-        export AZURE_STORAGE_KEY=$(cat /opt/azure-credentials/storage-key)
-        export ARM_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
-        export ARM_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
-        export ARM_LOCATION_NAME=$(cat /opt/azure-credentials/location)
-        export ARM_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
-        export ARM_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
-        BLOB=$(cat /opt/azure-credentials/blob)
+        BUCKET=$(cat /opt/gcp-credentials/bucket)
+        export GOOGLE_CREDENTIALS=$(cat /opt/gcp-credentials/credentials)
+        export GOOGLE_PROJECT=$(cat /opt/gcp-credentials/project)
+        export GOOGLE_REGION=$(cat /opt/gcp-credentials/region)
 
         # If debug add verbosity and print masked credentials
         if [[ "$(params.debug)" == "true" ]]; then
-          echo "AZURE_STORAGE_ACCOUNT"=$(mask_credential "$AZURE_STORAGE_ACCOUNT")
-          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
-          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
-          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
-          echo "ARM_LOCATION_NAME"=$ARM_LOCATION_NAME
-          echo "ARM_SUBSCRIPTION_ID"=$(mask_credential "$ARM_SUBSCRIPTION_ID")
-          echo "ARM_TENANT_ID"=$(mask_credential "$ARM_TENANT_ID")
-          echo "BLOB"=$BLOB
+          echo "BUCKET"=$BUCKET
+          echo "GOOGLE_CREDENTIALS=$(mask_credential "$GOOGLE_CREDENTIALS")"
+          echo "GOOGLE_PROJECT=$(mask_credential "$GOOGLE_PROJECT")"
+          echo "GOOGLE_REGION=$GOOGLE_REGION"
           set -xeuo pipefail
         fi
 
@@ -119,7 +107,7 @@ spec:
             echo "ERROR: workspace 'data' must be bound for create operation"
             exit 1
           fi
-          cmd+="rhelai az "
+          cmd+="rhelai gcp "
           cmd+="--image-path /data/$(params.image-path) "
           cmd+="--image-name $(params.image-name) "
 
@@ -147,7 +135,7 @@ spec:
         fi
 
         cmd+="--project-name $(params.id) "
-        cmd+="--backed-url azblob://${BLOB}/cloud-importer "
+        cmd+="--backed-url gs://${BUCKET}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
           cmd+="--debug "
@@ -156,9 +144,9 @@ spec:
         eval ${cmd}
 
       volumeMounts:
-        - name: az-credentials
-          mountPath: /opt/az-credentials
+        - name: gcp-credentials
+          mountPath: /opt/gcp-credentials
   volumes:
-    - name: az-credentials
+    - name: gcp-credentials
       secret:
-        secretName: $(params.secret-az-credentials)
+        secretName: $(params.secret-gcp-credentials)

--- a/tkn/snc-aws.yaml
+++ b/tkn/snc-aws.yaml
@@ -14,27 +14,57 @@ spec:
   description: >-
     This Task imports an OpenShift Local bundle to AWS using the cloud-importer tool.
   params:
-    - name: bundle-uri
-      description: Accessible URL to get the bundle.
-    - name: shasum-uri
-      description: Accessible URL to get the shasum file to check bundle.
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the AWS credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+
+    # uploading of images
     - name: arch
       description: Architecture for the machine (x86_64 or arm64).
       default: "x86_64"
-    - name: share-orgs-ids
-      description: "A comma-separated list of organization ARNs to share the AMI with."
+    - name: bundle-uri
+      description: Accessible URL to get the bundle.
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the image to."
       default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
-  workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/aws-credentials
+    - name: share-orgs-ids
+      description: "A comma-separated list of organization ARNs to share the image with."
+      default: ""
+    - name: shasum-uri
+      description: Accessible URL to get the shasum file to check bundle.
+      default: ""
+    - name: tags
+      description: "A comma-separated list of tags to add to the image."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the S3 backend after successful destroy
+      default: "false"
   steps:
     - name: run-cloud-importer
       image: quay.io/aipcc-cicd/cloud-importer:v1.0.0-dev
@@ -69,21 +99,48 @@ spec:
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer snc aws --arch $(params.arch) "
-        cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
-        cmd+="--backed-url s3://${BUCKET}/cloud-importer/$(params.id) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          cmd+="snc aws "
+          cmd+="--arch $(params.arch) "
+          cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
 
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+=" --share-orgs-ids=$(params.share-orgs-ids)"
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+=" --replicate=$(params.replicate-to-regions)"
-        fi
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
-          cmd+="--debug"
+          cmd+="--debug "
         fi
 
         eval ${cmd}
 
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)

--- a/tkn/snc-azure.yaml
+++ b/tkn/snc-azure.yaml
@@ -14,27 +14,61 @@ spec:
   description: >-
     This Task imports an OpenShift Local bundle to Azure using the cloud-importer tool.
   params:
-    - name: bundle-uri
-      description: Accessible URL to get the bundle.
-    - name: shasum-uri
-      description: Accessible URL to get the shasum file to check bundle.
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-az-credentials
+      description: |
+        K8S secret holding the Azure credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: azure-${name}
+        type: Opaque
+        data:
+          blob: ${blob}
+          client-id: ${client_id}
+          client-secret: ${client_secret}
+          location: ${location}
+          storage-account: ${storage_account}
+          storage-key: ${storage_key}
+          subscription-id: ${subscription_id}
+          tenant-id: ${tenant_id}
+
+    # uploading of images
     - name: arch
       description: Architecture for the machine (x86_64 or arm64).
       default: "x86_64"
-    - name: share-orgs-ids
-      description: "A comma-separated list of organization ARNs to share the AMI with."
+    - name: bundle-uri
+      description: Accessible URL to get the bundle.
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the image to."
       default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
-  workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/az-credentials
+    - name: share-orgs-ids
+      description: "A comma-separated list of organization tenant IDs to share the image with."
+      default: ""
+    - name: shasum-uri
+      description: Accessible URL to get the shasum file to check bundle.
+      default: ""
+    - name: tags
+      description: "A comma-separated list of tags to add to the image."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      default: "false"
   steps:
     - name: run-cloud-importer
       image: quay.io/aipcc-cicd/cloud-importer:v1.0.0-dev
@@ -55,40 +89,70 @@ spec:
         }
 
         # Credentials - set these BEFORE enabling debug mode
-        export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
-        export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
-        export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
-        export ARM_CLIENT_SECRET=$(cat /opt/az-credentials/client_secret)
-        export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
-        export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
-        BLOB=$(cat /opt/az-credentials/blob)
+        export AZURE_STORAGE_ACCOUNT=$(cat /opt/azure-credentials/storage-account)
+        export AZURE_STORAGE_KEY=$(cat /opt/azure-credentials/storage-key)
+        export ARM_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
+        export ARM_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
+        export ARM_LOCATION_NAME=$(cat /opt/azure-credentials/location)
+        export ARM_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
+        export ARM_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
+        BLOB=$(cat /opt/azure-credentials/blob)
 
         # If debug add verbosity and print masked credentials
         if [[ "$(params.debug)" == "true" ]]; then
-          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
-          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "AZURE_STORAGE_ACCOUNT"=$(mask_credential "$AZURE_STORAGE_ACCOUNT")
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
           echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
           echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
-          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
-          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
-          echo "BLOB=$BLOB"
+          echo "ARM_LOCATION_NAME"=$ARM_LOCATION_NAME
+          echo "ARM_SUBSCRIPTION_ID"=$(mask_credential "$ARM_SUBSCRIPTION_ID")
+          echo "ARM_TENANT_ID"=$(mask_credential "$ARM_TENANT_ID")
+          echo "BLOB"=$BLOB
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer snc az --arch $(params.arch) "
-        cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
-        cmd+="--backed-url azblob://${BLOB}/cloud-importer-crc-bundle-$(params.id) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          cmd+="snc az "
+          cmd+="--arch $(params.arch) "
+          cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
 
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+=" --share-orgs-ids=$(params.share-orgs-ids)"
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+=" --replicate=$(params.replicate-to-regions)"
-        fi
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url azblob://${BLOB}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
           cmd+="--debug"
         fi
 
         eval ${cmd}
+
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/az-credentials
+  volumes:
+    - name: az-credentials
+      secret:
+        secretName: $(params.secret-az-credentials)

--- a/tkn/template/rhelai-aws.yaml
+++ b/tkn/template/rhelai-aws.yaml
@@ -14,30 +14,59 @@ spec:
   description: >-
     This Task imports a RAW image to AWS using the cloud-importer tool.
   params:
-    - name: raw-image-path
-      description: Local path to the raw image.
-    - name: ami-name
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the AWS credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+
+    # uploading of images
+    - name: image-name
       description: The name of the AMI to be created.
-    - name: share-with-account-ids
-      description: "A comma-separated list of account IDs to share the AMI with."
       default: ""
+    - name: image-path
+      description: Local path to the raw image.
+      default: ""
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the AMI to."
+      default: "all"
     - name: share-orgs-ids
       description: "A comma-separated list of organization ARNs to share the AMI with."
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
-      default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
+    - name: tags
+      description: "A comma-separated list of tags to add to the AMI."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the S3 backend after successful destroy
+      default: "false"
   workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/aws-credentials
     - name: data
       description: A workspace for the raw image.
       mountPath: /data
+      optional: true
   steps:
     - name: run-cloud-importer
       image: <IMAGE>
@@ -72,20 +101,52 @@ spec:
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer rhelai aws --output /data/output.json --image-path /data/$(params.raw-image-path) "
-        cmd+="--image-name $(params.ami-name) "
-        cmd+="--backed-url s3://${BUCKET}/cloud-importer/$(params.id) "
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          if [[ "$(workspaces.data.bound)" != "true" ]]; then
+            echo "ERROR: workspace 'data' must be bound for create operation"
+            exit 1
+          fi
+          cmd+="rhelai aws "
+          cmd+="--image-path /data/$(params.image-path) "
+          cmd+="--image-name $(params.image-name) "
+
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+="--replicate=$(params.replicate-to-regions) "
-        fi
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
-          cmd+="--debug"
+          cmd+="--debug "
         fi
 
         eval ${cmd}
 
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)

--- a/tkn/template/rhelai-gcp.yaml
+++ b/tkn/template/rhelai-gcp.yaml
@@ -1,18 +1,18 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: cloud-importer-azure
+  name: cloud-importer-rhelai-gcp
   labels:
     app.kubernetes.io/version: "<VERSION>"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/categories: infrastructure
-    tekton.dev/tags: infrastructure, azure, rhelai
-    tekton.dev/displayName: "CloudImporter Azure"
+    tekton.dev/tags: infrastructure, gcp, rhelai
+    tekton.dev/displayName: "CloudImporter RHEL-AI GCP"
     tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
-    This Task imports a RAW image to Azure using the cloud-importer tool.
+    This Task imports a RAW image to GCP using the cloud-importer tool.
   params:
     # general
     - name: debug
@@ -22,32 +22,28 @@ spec:
     - name: operation
       description: operation to perform (create or destroy)
       default: create
-    - name: secret-az-credentials
+    - name: secret-gcp-credentials
       description: |
-        K8S secret holding the Azure credentials. Secret should be accessible to this task.
+        K8S secret holding the GCP credentials. Secret should be accessible to this task.
 
         ---
         apiVersion: v1
         kind: Secret
         metadata:
-          name: azure-${name}
+          name: gcp-${name}
         type: Opaque
         data:
-          blob: ${blob}
-          client-id: ${client_id}
-          client-secret: ${client_secret}
-          location: ${location}
-          storage-account: ${storage_account}
-          storage-key: ${storage_key}
-          subscription-id: ${subscription_id}
-          tenant-id: ${tenant_id}
+          bucket: ${bucket}
+          credentials: ${credentials}
+          project: ${project}
+          region: ${region}
 
     # uploading of images
     - name: image-name
-      description: The name for the image in Azure.
+      description: The name of the image to be created.
       default: ""
     - name: image-path
-      description: Local path to the vhd image.
+      description: Local path to the raw image.
       default: ""
     - name: replicate
       description: "A comma-separated list of regions to replicate the image to."
@@ -64,11 +60,11 @@ spec:
       description: destroy even if there is a lock
       default: "false"
     - name: keep-state
-      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      description: keep the Pulumi state in the GCS backend after successful destroy
       default: "false"
   workspaces:
     - name: data
-      description: A workspace for the vhd image.
+      description: A workspace for the raw image.
       mountPath: /data
       optional: true
   steps:
@@ -91,25 +87,17 @@ spec:
         }
 
         # Credentials - set these BEFORE enabling debug mode
-        export AZURE_STORAGE_ACCOUNT=$(cat /opt/azure-credentials/storage-account)
-        export AZURE_STORAGE_KEY=$(cat /opt/azure-credentials/storage-key)
-        export ARM_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
-        export ARM_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
-        export ARM_LOCATION_NAME=$(cat /opt/azure-credentials/location)
-        export ARM_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
-        export ARM_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
-        BLOB=$(cat /opt/azure-credentials/blob)
+        BUCKET=$(cat /opt/gcp-credentials/bucket)
+        export GOOGLE_CREDENTIALS=$(cat /opt/gcp-credentials/credentials)
+        export GOOGLE_PROJECT=$(cat /opt/gcp-credentials/project)
+        export GOOGLE_REGION=$(cat /opt/gcp-credentials/region)
 
         # If debug add verbosity and print masked credentials
         if [[ "$(params.debug)" == "true" ]]; then
-          echo "AZURE_STORAGE_ACCOUNT"=$(mask_credential "$AZURE_STORAGE_ACCOUNT")
-          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
-          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
-          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
-          echo "ARM_LOCATION_NAME"=$ARM_LOCATION_NAME
-          echo "ARM_SUBSCRIPTION_ID"=$(mask_credential "$ARM_SUBSCRIPTION_ID")
-          echo "ARM_TENANT_ID"=$(mask_credential "$ARM_TENANT_ID")
-          echo "BLOB"=$BLOB
+          echo "BUCKET"=$BUCKET
+          echo "GOOGLE_CREDENTIALS=$(mask_credential "$GOOGLE_CREDENTIALS")"
+          echo "GOOGLE_PROJECT=$(mask_credential "$GOOGLE_PROJECT")"
+          echo "GOOGLE_REGION=$GOOGLE_REGION"
           set -xeuo pipefail
         fi
 
@@ -119,7 +107,7 @@ spec:
             echo "ERROR: workspace 'data' must be bound for create operation"
             exit 1
           fi
-          cmd+="rhelai az "
+          cmd+="rhelai gcp "
           cmd+="--image-path /data/$(params.image-path) "
           cmd+="--image-name $(params.image-name) "
 
@@ -147,7 +135,7 @@ spec:
         fi
 
         cmd+="--project-name $(params.id) "
-        cmd+="--backed-url azblob://${BLOB}/cloud-importer "
+        cmd+="--backed-url gs://${BUCKET}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
           cmd+="--debug "
@@ -156,9 +144,9 @@ spec:
         eval ${cmd}
 
       volumeMounts:
-        - name: az-credentials
-          mountPath: /opt/az-credentials
+        - name: gcp-credentials
+          mountPath: /opt/gcp-credentials
   volumes:
-    - name: az-credentials
+    - name: gcp-credentials
       secret:
-        secretName: $(params.secret-az-credentials)
+        secretName: $(params.secret-gcp-credentials)

--- a/tkn/template/snc-aws.yaml
+++ b/tkn/template/snc-aws.yaml
@@ -14,27 +14,57 @@ spec:
   description: >-
     This Task imports an OpenShift Local bundle to AWS using the cloud-importer tool.
   params:
-    - name: bundle-uri
-      description: Accessible URL to get the bundle.
-    - name: shasum-uri
-      description: Accessible URL to get the shasum file to check bundle.
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the AWS credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+
+    # uploading of images
     - name: arch
       description: Architecture for the machine (x86_64 or arm64).
       default: "x86_64"
-    - name: share-orgs-ids
-      description: "A comma-separated list of organization ARNs to share the AMI with."
+    - name: bundle-uri
+      description: Accessible URL to get the bundle.
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the image to."
       default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
-  workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/aws-credentials
+    - name: share-orgs-ids
+      description: "A comma-separated list of organization ARNs to share the image with."
+      default: ""
+    - name: shasum-uri
+      description: Accessible URL to get the shasum file to check bundle.
+      default: ""
+    - name: tags
+      description: "A comma-separated list of tags to add to the image."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the S3 backend after successful destroy
+      default: "false"
   steps:
     - name: run-cloud-importer
       image: <IMAGE>
@@ -69,21 +99,48 @@ spec:
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer snc aws --arch $(params.arch) "
-        cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
-        cmd+="--backed-url s3://${BUCKET}/cloud-importer/$(params.id) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          cmd+="snc aws "
+          cmd+="--arch $(params.arch) "
+          cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
 
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+="--replicate=$(params.replicate-to-regions) "
-        fi
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
-          cmd+="--debug"
+          cmd+="--debug "
         fi
 
         eval ${cmd}
 
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)

--- a/tkn/template/snc-azure.yaml
+++ b/tkn/template/snc-azure.yaml
@@ -14,27 +14,61 @@ spec:
   description: >-
     This Task imports an OpenShift Local bundle to Azure using the cloud-importer tool.
   params:
-    - name: bundle-uri
-      description: Accessible URL to get the bundle.
-    - name: shasum-uri
-      description: Accessible URL to get the shasum file to check bundle.
+    # general
+    - name: debug
+      description: run with deug logs
+    - name: id
+      description: identifier for the taskrun
+    - name: operation
+      description: operation to perform (create or destroy)
+      default: create
+    - name: secret-az-credentials
+      description: |
+        K8S secret holding the Azure credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: azure-${name}
+        type: Opaque
+        data:
+          blob: ${blob}
+          client-id: ${client_id}
+          client-secret: ${client_secret}
+          location: ${location}
+          storage-account: ${storage_account}
+          storage-key: ${storage_key}
+          subscription-id: ${subscription_id}
+          tenant-id: ${tenant_id}
+
+    # uploading of images
     - name: arch
       description: Architecture for the machine (x86_64 or arm64).
       default: "x86_64"
-    - name: share-orgs-ids
-      description: "A comma-separated list of organization ARNs to share the AMI with."
+    - name: bundle-uri
+      description: Accessible URL to get the bundle.
       default: ""
-    - name: replicate-to-regions
-      description: "A comma-separated list of regions to replicate the AMI to."
+    - name: replicate
+      description: "A comma-separated list of regions to replicate the image to."
       default: "all"
-    - name: id
-      description: identifier for the taskrun
-    - name: debug
-      description: run with deug logs
-  workspaces:
-    - name: credentials
-      description: A workspace containing the cloud provider credentials.
-      mountPath: /opt/az-credentials
+    - name: share-orgs-ids
+      description: "A comma-separated list of organization tenant IDs to share the image with."
+      default: ""
+    - name: shasum-uri
+      description: Accessible URL to get the shasum file to check bundle.
+      default: ""
+    - name: tags
+      description: "A comma-separated list of tags to add to the image."
+      default: ""
+
+    # removal of images
+    - name: force-destroy
+      description: destroy even if there is a lock
+      default: "false"
+    - name: keep-state
+      description: keep the Pulumi state in the Azure Blob backend after successful destroy
+      default: "false"
   steps:
     - name: run-cloud-importer
       image: <IMAGE>
@@ -55,40 +89,70 @@ spec:
         }
 
         # Credentials - set these BEFORE enabling debug mode
-        export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
-        export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
-        export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
-        export ARM_CLIENT_SECRET=$(cat /opt/az-credentials/client_secret)
-        export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
-        export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
-        BLOB=$(cat /opt/az-credentials/blob)
+        export AZURE_STORAGE_ACCOUNT=$(cat /opt/azure-credentials/storage-account)
+        export AZURE_STORAGE_KEY=$(cat /opt/azure-credentials/storage-key)
+        export ARM_CLIENT_ID=$(cat /opt/azure-credentials/client-id)
+        export ARM_CLIENT_SECRET=$(cat /opt/azure-credentials/client-secret)
+        export ARM_LOCATION_NAME=$(cat /opt/azure-credentials/location)
+        export ARM_SUBSCRIPTION_ID=$(cat /opt/azure-credentials/subscription-id)
+        export ARM_TENANT_ID=$(cat /opt/azure-credentials/tenant-id)
+        BLOB=$(cat /opt/azure-credentials/blob)
 
         # If debug add verbosity and print masked credentials
         if [[ "$(params.debug)" == "true" ]]; then
-          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
-          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "AZURE_STORAGE_ACCOUNT"=$(mask_credential "$AZURE_STORAGE_ACCOUNT")
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
           echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
           echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
-          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
-          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
-          echo "BLOB=$BLOB"
+          echo "ARM_LOCATION_NAME"=$ARM_LOCATION_NAME
+          echo "ARM_SUBSCRIPTION_ID"=$(mask_credential "$ARM_SUBSCRIPTION_ID")
+          echo "ARM_TENANT_ID"=$(mask_credential "$ARM_TENANT_ID")
+          echo "BLOB"=$BLOB
           set -xeuo pipefail
         fi
 
-        cmd="cloud-importer snc az --arch $(params.arch) "
-        cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
-        cmd+="--backed-url azblob://${BLOB}/cloud-importer-crc-bundle-$(params.id) "
+        cmd="cloud-importer "
+        if [[ "$(params.operation)" == "create" ]]; then
+          cmd+="snc az "
+          cmd+="--arch $(params.arch) "
+          cmd+="--bundle-uri \"$(params.bundle-uri)\" --shasum-uri \"$(params.shasum-uri)\" "
 
-        if [ -n "$(params.share-orgs-ids)" ]; then
-          cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          if [ -n "$(params.share-orgs-ids)" ]; then
+            cmd+="--share-orgs-ids=$(params.share-orgs-ids) "
+          fi
+
+          if [ -n "$(params.replicate)" ]; then
+            cmd+="--replicate=$(params.replicate) "
+          fi
+
+          if [ -n "$(params.tags)" ]; then
+            cmd+="--tags=$(params.tags) "
+          fi
+        else
+          cmd+="destroy "
+
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
         fi
 
-        if [ -n "$(params.replicate-to-regions)" ]; then
-          cmd+="--replicate=$(params.replicate-to-regions) "
-        fi
+        cmd+="--project-name $(params.id) "
+        cmd+="--backed-url azblob://${BLOB}/cloud-importer "
 
         if [[ "$(params.debug)" == "true" ]]; then
           cmd+="--debug"
         fi
 
         eval ${cmd}
+
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/az-credentials
+  volumes:
+    - name: az-credentials
+      secret:
+        secretName: $(params.secret-az-credentials)


### PR DESCRIPTION
…CP support

Add GCP Tekton task (rhelai-gcp) for importing RHEL AI images to GCP.

BREAKING CHANGE: Tekton task parameters have been renamed and restructured:
- `raw-image-path` renamed to `image-path`
- `ami-name` renamed to `image-name`
- `replicate-to-regions` renamed to `replicate`
- `share-with-account-ids` removed
- `credentials` workspace removed — credentials are now provided via K8S secrets referenced by `secret-aws-credentials`, `secret-az-credentials`, or `secret-gcp-credentials` params
- Azure env vars renamed to match cloud-importer CLI expectations (AZURE_CLIENT_ID -> ARM_CLIENT_ID, etc.)

New parameters added to all tasks:
- `operation` (create/destroy) to support destroy from the same task
- `force-destroy` and `keep-state` for destroy operations
- `tags` for tagging images
- `secret-*-credentials` for K8S secret-based credential injection